### PR TITLE
Adding support for map/repeatable elements

### DIFF
--- a/src/protobuf_to_dict.py
+++ b/src/protobuf_to_dict.py
@@ -46,6 +46,9 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
     result_dict = {}
     extensions = {}
     for field, value in pb.ListFields():
+        if field.message_type and field.message_type.has_options and field.message_type.GetOptions().map_entry:
+            result_dict[field.name] = dict(value)
+            continue
         type_callable = _get_field_value_adaptor(pb, field, type_callable_map, use_enum_labels)
         if field.label == FieldDescriptor.LABEL_REPEATED:
             type_callable = repeated(type_callable)


### PR DESCRIPTION
Adding support for repeatable map elements which will otherwise throw the error `'str' object has no attribute 'ListFields'` as per this pull request: https://github.com/benhodgson/protobuf-to-dict/pull/9