### PR TITLE
Add ignore_none for dict_to_protobuf

### DIFF
--- a/src/tests/test_proto_to_dict.py
+++ b/src/tests/test_proto_to_dict.py
@@ -123,6 +123,27 @@ class Test(unittest.TestCase):
         m2 = dict_to_protobuf(MessageOfTypes, d)
         assert m == m2
 
+    def test_ignore_none(self):
+        m = MessageOfTypes()
+        d = protobuf_to_dict(m)
+        assert d == {}
+
+        for field in m.DESCRIPTOR.fields:
+            d[field.name] = None
+
+        m2 = dict_to_protobuf(MessageOfTypes, d, ignore_none=True)
+        assert m == m2
+
+    def test_nested_ignore_none(self):
+        m = MessageOfTypes()
+        m.nestedMap['123'].req = '42'
+
+        d = protobuf_to_dict(m)
+        d['nestedMap']['123']['req'] = None
+
+        m2 = dict_to_protobuf(MessageOfTypes, d, ignore_none=True)
+        assert m2.nestedMap['123'].req == ''
+
     def populate_MessageOfTypes(self):
         m = MessageOfTypes()
         m.dubl = 1.7e+308


### PR DESCRIPTION
This option enables creating of protobuf objects from dicts, in which
some values are None. Such value is treated as absence
of the appropriate key.