### PR TITLE
Add including_default_value_fields for protobuf_to_dict

### DIFF
--- a/src/protobuf_to_dict.py
+++ b/src/protobuf_to_dict.py
@@ -57,11 +57,13 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
             result_dict[field.name] = dict()
             value_field = field.message_type.fields_by_name['value']
             type_callable = _get_field_value_adaptor(
-                pb, value_field, type_callable_map, use_enum_labels)
+                pb, value_field, type_callable_map,
+                use_enum_labels, including_default_value_fields)
             for k, v in value.items():
                 result_dict[field.name][k] = type_callable(v)
             continue
-        type_callable = _get_field_value_adaptor(pb, field, type_callable_map, use_enum_labels)
+        type_callable = _get_field_value_adaptor(pb, field, type_callable_map,
+                                                 use_enum_labels, including_default_value_fields)
         if field.label == FieldDescriptor.LABEL_REPEATED:
             type_callable = repeated(type_callable)
 
@@ -93,12 +95,15 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
     return result_dict
 
 
-def _get_field_value_adaptor(pb, field, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=False):
+def _get_field_value_adaptor(pb, field, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=False,
+                             including_default_value_fields=False):
     if field.type == FieldDescriptor.TYPE_MESSAGE:
         # recursively encode protobuf sub-message
         return lambda pb: protobuf_to_dict(
             pb, type_callable_map=type_callable_map,
-            use_enum_labels=use_enum_labels)
+            use_enum_labels=use_enum_labels,
+            including_default_value_fields=including_default_value_fields,
+        )
 
     if use_enum_labels and field.type == FieldDescriptor.TYPE_ENUM:
         return lambda value: enum_label_name(field, value)

--- a/src/tests/test_proto_to_dict.py
+++ b/src/tests/test_proto_to_dict.py
@@ -110,6 +110,19 @@ class Test(unittest.TestCase):
         m2 = dict_to_protobuf(MessageOfTypes, d)
         assert m == m2
 
+    def test_including_default_value_fields(self):
+        m = MessageOfTypes()
+        d = protobuf_to_dict(m)
+        assert d == {}
+
+        d = protobuf_to_dict(m, including_default_value_fields=True)
+        for field in m.DESCRIPTOR.fields:
+            if field.name != 'nested':
+                assert field.name in d, field.name
+
+        m2 = dict_to_protobuf(MessageOfTypes, d)
+        assert m == m2
+
     def populate_MessageOfTypes(self):
         m = MessageOfTypes()
         m.dubl = 1.7e+308


### PR DESCRIPTION
This option has the same behavior as google.protobuf.json_format.MessageToJson:
if a singular primitive field has no value, it is filled with a default value.