### PR TITLE
Fix bytes protobuf type

### DIFF
--- a/src/protobuf_to_dict.py
+++ b/src/protobuf_to_dict.py
@@ -29,7 +29,7 @@ TYPE_CALLABLE_MAP = {
     FieldDescriptor.TYPE_SFIXED64: int if six.PY3 else six.integer_types[1],
     FieldDescriptor.TYPE_BOOL: bool,
     FieldDescriptor.TYPE_STRING: six.text_type,
-    FieldDescriptor.TYPE_BYTES: lambda b: base64.b64encode(b),
+    FieldDescriptor.TYPE_BYTES: six.binary_type,
     FieldDescriptor.TYPE_ENUM: int,
 }
 
@@ -120,7 +120,6 @@ def get_bytes(value):
 
 
 REVERSE_TYPE_CALLABLE_MAP = {
-    FieldDescriptor.TYPE_BYTES: get_bytes,
 }
 
 

--- a/src/protobuf_to_dict.py
+++ b/src/protobuf_to_dict.py
@@ -115,10 +115,6 @@ def _get_field_value_adaptor(pb, field, type_callable_map=TYPE_CALLABLE_MAP, use
         pb.__class__.__name__, field.name, field.type))
 
 
-def get_bytes(value):
-    return base64.b64decode(value)
-
-
 REVERSE_TYPE_CALLABLE_MAP = {
 }
 

--- a/src/tests/test_proto_to_dict.py
+++ b/src/tests/test_proto_to_dict.py
@@ -177,5 +177,5 @@ class Test(unittest.TestCase):
                 assert field.name in d, field.name
                 assert d[field.name] == getattr(m, field.name), (field.name, d[field.name])
         assert i > 0
-        assert m.byts == base64.b64decode(d['byts'])
+        assert m.byts == d['byts']
         assert d['nested'] == {'req': m.nested.req}


### PR DESCRIPTION
This is how bytes should be treated to work correctly with Python 3.x and protobuf3.