### PR TITLE
Remove deprecated use of FieldDescriptor.LABEL_REPEATED

### DIFF
--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -80,7 +80,7 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
         type_callable = _get_field_value_adaptor(pb, field, type_callable_map,
                                                  use_enum_labels, including_default_value_fields,
                                                  lowercase_enum_lables)
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if field.is_repeated:
             type_callable = repeated(type_callable)
 
         if field.is_extension:
@@ -94,7 +94,7 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
         for field in pb.DESCRIPTOR.fields:
             # Singular message fields and oneof fields will not be affected.
             if ((
-                    field.label != FieldDescriptor.LABEL_REPEATED and
+                    field.is_repeated and
                     field.cpp_type == FieldDescriptor.CPPTYPE_MESSAGE) or
                     field.containing_oneof):
                 continue
@@ -103,7 +103,7 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
                 continue
             if _is_map_entry(field):
                 result_dict[field.name] = {}
-            elif field.label == FieldDescriptor.LABEL_REPEATED:
+            elif field.is_repeated:
                 result_dict[field.name] = []
             elif field.type == FieldDescriptor.TYPE_ENUM and use_enum_labels:
                 result_dict[field.name] = enum_label_name(field, field.default_value, lowercase_enum_lables)
@@ -198,7 +198,7 @@ def _dict_to_protobuf(pb, value, type_callable_map, strict, ignore_none):
     for field, input_value, pb_value in fields:
         if ignore_none and input_value is None:
             continue
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if field.is_repeated:
             if field.message_type and field.message_type.has_options and field.message_type.GetOptions().map_entry:
                 key_field = field.message_type.fields_by_name['key']
                 value_field = field.message_type.fields_by_name['value']


### PR DESCRIPTION
Hi there!
I noticed this repository has not seen much activity recently, and I also see a good number of forks out there. 
AFAICT, this repository is the one used to upload to https://pypi.org/project/protobuf3-to-dict/, so I guess this is the "right" one to push fixes to.

This PR fixes the use of a now deprecated API to get labels information in protobuf.
It produces lots of [warnings](https://github.com/protocolbuffers/protobuf/commit/64a76e68e08ba3a55e6cfd94c9df006d0b21239e) in the current state, here are details about the deprecation https://protobuf.dev/news/v31/